### PR TITLE
Fixed readme code chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,18 +58,18 @@ Install with [NPM](http://npmjs.org)
 ### Use in browser
 
 Insert in your html code:
-    ```html
-    <script type="text/javascript" src="/path/to/your/js/libs/Hydra.js"></script>
-    ```
+```html
+<script type="text/javascript" src="/path/to/your/js/libs/Hydra.js"></script>
+```
 ### Common usage
 #### Setting variables
 
-    ```js
-    Hydra.module.setVars({
-        gaq: _gaq,
-        list: document.getElementById( "list" )
-    });
-    ```
+```js
+Hydra.module.setVars({
+    gaq: _gaq,
+    list: document.getElementById( "list" )
+});
+```
 
 Setting the variables in this way will make the variables accessible as the last argument in the init module method. If needed you can also access these
 variables using getVars (See 'Getting variables')
@@ -78,9 +78,9 @@ variables using getVars (See 'Getting variables')
 
 #### Getting variables
 
-    ```js
-    var oVars = Hydra.module.getVars();
-    ```
+```js
+var oVars = Hydra.module.getVars();
+```
 Returns the object with the private variables set using setVars (See 'Setting variables')
 
 #### Module creator function
@@ -95,35 +95,35 @@ The module creator function gets four arguments:
 * **Api**
 * Get access to the rest of the Hydra api. You can use it to access to the current extensions, i.e. jQuery, or to your own extensions.
 
-    ```js
-    function( Bus, Module, ErrorHandler, Api )
-    {
-        return {
-            init: function ( oData ) {}
-        };
-    }
-    ```
+```js
+function( Bus, Module, ErrorHandler, Api )
+{
+    return {
+        init: function ( oData ) {}
+    };
+}
+```
 
 #### Create a module
 
-    ```js
-    Hydra.module.register( 'moduleId', function( Bus, Module, ErrorHandler, Api )
-    {
-        return {
-            init: function ( oData ) {}
-        };
-    });
-    ```
+```js
+Hydra.module.register( 'moduleId', function( Bus, Module, ErrorHandler, Api )
+{
+    return {
+        init: function ( oData ) {}
+    };
+});
+```
 
 #### Create a module using dependency injection
-    ```js
-    Hydra.module.register( 'moduleId', ['$api', '$bus'], function ( Api, Bus )
-    {
-        return {
-            init: function ( oData ) {}
-        };
-    });
-    ```
+```js
+Hydra.module.register( 'moduleId', ['$api', '$bus'], function ( Api, Bus )
+{
+    return {
+        init: function ( oData ) {}
+    };
+});
+```
 
 The following are available for dependency injection:
 
@@ -140,26 +140,26 @@ Hydra will pass them in the order specified to your function.
 #### Extend a module overriding the base module
 To extend a module you will need to register the base module before extends it.
 
-    ```js
-    Hydra.module.extend( 'moduleId', function( Bus, Module, ErrorHandler, Api )
-    {
-        return {
-            init: function ( oData ) {}
-        };
-    });
-    ```
+```js
+Hydra.module.extend( 'moduleId', function( Bus, Module, ErrorHandler, Api )
+{
+    return {
+        init: function ( oData ) {}
+    };
+});
+```
 
 #### Extend a module creating a new module
 To extend a module you will need to register the base module before extends it.
 
-    ```js
-    Hydra.module.extend( 'moduleId', 'newModuleId', function( Bus, Module, ErrorHandler, Api )
-    {
-        return {
-            init: function ( oData ) {}
-        };
-    });
-    ```
+```js
+Hydra.module.extend( 'moduleId', 'newModuleId', function( Bus, Module, ErrorHandler, Api )
+{
+    return {
+        init: function ( oData ) {}
+    };
+});
+```
 
 This extension allows access the parent methods as classical inheritance.
 
@@ -167,102 +167,102 @@ This extension allows access the parent methods as classical inheritance.
 
 Register base module:
 
-    ```js
-    Hydra.module.register( 'moduleId', function( Bus, Module, ErrorHandler, Api )
-    {
-        return {
-            init: function ( oData ) {},
-            changeTitle: function( sTitle ){
-                document.title = sTitle;
-            }
-        };
-    });
-    ```
+```js
+Hydra.module.register( 'moduleId', function( Bus, Module, ErrorHandler, Api )
+{
+    return {
+        init: function ( oData ) {},
+        changeTitle: function( sTitle ){
+            document.title = sTitle;
+        }
+    };
+});
+```
 
 Create the new module using "extend":
 
-    ```js
-    Hydra.module.extend( 'moduleId', 'newModuleId', function( Bus, Module, ErrorHandler, Api )
-    {
-        return {
-            init: function ( oData ) {},
-            changeTitle: function( sTitle ){
-                sTitle += " " + new Date().getTime();
-                // This is the way of access parent methods.
-                this.__super__.call( "changeTitle", [sTitle] );
-            }
-        };
-    });
-    ```
+```js
+Hydra.module.extend( 'moduleId', 'newModuleId', function( Bus, Module, ErrorHandler, Api )
+{
+    return {
+        init: function ( oData ) {},
+        changeTitle: function( sTitle ){
+            sTitle += " " + new Date().getTime();
+            // This is the way of access parent methods.
+            this.__super__.call( "changeTitle", [sTitle] );
+        }
+    };
+});
+```
 
 #### Decorating modules
 Sometimes is better to decorate our modules instead of extending them. I recommend to use decorate instead of extend modules.
 
-    ```js
-    Hydra.module.decorate( 'baseModuleId', 'decoratedModuleId', function( Bus, baseModule, Module, ErrorHandler, Api )
-    {
-        return {
-            init: function ()
-            {
-                //do something on start a module
-                baseModule.init();
-            },
-            onDestroy: function ()
-            {
-                //do something on stop a module
-                baseModule.onDestroy();
-            }
-        };
-    });
-    ```
+```js
+Hydra.module.decorate( 'baseModuleId', 'decoratedModuleId', function( Bus, baseModule, Module, ErrorHandler, Api )
+{
+    return {
+        init: function ()
+        {
+            //do something on start a module
+            baseModule.init();
+        },
+        onDestroy: function ()
+        {
+            //do something on stop a module
+            baseModule.onDestroy();
+        }
+    };
+});
+```
 
 #### Listening to events
-    ```js
-    Hydra.module.register( 'moduleId', function( Bus, Module, ErrorHandler, Api )
-    {
-        return {
-            events : {
-                'channel': {
-                    'item:action1': function ( oData ) {}
-                }
-            },
-            init: function ( oData ) {
-                /* The subscribing of events is done by Hydra inside the core.
-                * Bus.subscribe( this );
-                */
+```js
+Hydra.module.register( 'moduleId', function( Bus, Module, ErrorHandler, Api )
+{
+    return {
+        events : {
+            'channel': {
+                'item:action1': function ( oData ) {}
             }
-        };
-    });
-    ```
+        },
+        init: function ( oData ) {
+            /* The subscribing of events is done by Hydra inside the core.
+            * Bus.subscribe( this );
+            */
+        }
+    };
+});
+```
 
 #### Publishing actions
 To use the action manager you have accessible using "Bus".
 
 The publish method expect three arguments, but only the first two are mandatory, the channel name and the event name
 
-    ```js
-    Hydra.bus.publish( 'channel_name', 'event_name', data );
-    ```
+```js
+Hydra.bus.publish( 'channel_name', 'event_name', data );
+```
 
 *Tip: 'global' channel is created by default to use it if you want to communicate with other modules that are not related with a specific channel. *
 
-    ```js
-    Hydra.module.register( 'moduleId', function( Bus, Module, ErrorHandler, Api )
-    {
-        return {
-            events : {
-                'channel': {
-                    'item:action1': function ( oData ) {}
-                }
-            },
-            init: function ( oData ) {
-                $( "#button" ).click( function(){
-                    Bus.publish( 'channel', 'item:action1', {} );
-                });
+```js
+Hydra.module.register( 'moduleId', function( Bus, Module, ErrorHandler, Api )
+{
+    return {
+        events : {
+            'channel': {
+                'item:action1': function ( oData ) {}
             }
-        };
-    });
-    ```
+        },
+        init: function ( oData ) {
+            $( "#button" ).click( function(){
+                Bus.publish( 'channel', 'item:action1', {} );
+            });
+        }
+    };
+});
+```
 #### Preprocessing Data on publish actions.
 When the data is pass to the listener actions it gives the same object by default, if you need to pre-process this data before execute the action, you should use the 'preprocessorPublishData' method in Hydra.bus.
 The callback that you pass will get two arguments:
@@ -271,11 +271,11 @@ The callback that you pass will get two arguments:
 
 Example of a code that returns a copy of the data object
 
-    ```js
-    Hydra.bus.preprocessorPublishData( function ( oData, clone ) {
-        return clone( oData );
-    });
-    ```
+```js
+Hydra.bus.preprocessorPublishData( function ( oData, clone ) {
+    return clone( oData );
+});
+```
 If you need compatibility with the previous event manager called Action, you can add it in your code to maintain compatibility with previous version's code. You can download it from: [Action](https://github.com/tcorral/Hydra_Extensions/tree/master/Sandbox)
 
 

--- a/templates/README.tpl
+++ b/templates/README.tpl
@@ -58,18 +58,18 @@ Install with [NPM](http://npmjs.org)
 ### Use in browser
 
 Insert in your html code:
-    ```html
-    <script type="text/javascript" src="/path/to/your/js/libs/Hydra.js"></script>
-    ```
+```html
+<script type="text/javascript" src="/path/to/your/js/libs/Hydra.js"></script>
+```
 ### Common usage
 #### Setting variables
 
-    ```js
-    Hydra.module.setVars({
-        gaq: _gaq,
-        list: document.getElementById( "list" )
-    });
-    ```
+```js
+Hydra.module.setVars({
+    gaq: _gaq,
+    list: document.getElementById( "list" )
+});
+```
 
 Setting the variables in this way will make the variables accessible as the last argument in the init module method. If needed you can also access these
 variables using getVars (See 'Getting variables')
@@ -78,9 +78,9 @@ variables using getVars (See 'Getting variables')
 
 #### Getting variables
 
-    ```js
-    var oVars = Hydra.module.getVars();
-    ```
+```js
+var oVars = Hydra.module.getVars();
+```
 Returns the object with the private variables set using setVars (See 'Setting variables')
 
 #### Module creator function
@@ -95,35 +95,35 @@ The module creator function gets four arguments:
 * **Api**
 * Get access to the rest of the Hydra api. You can use it to access to the current extensions, i.e. jQuery, or to your own extensions.
 
-    ```js
-    function( Bus, Module, ErrorHandler, Api )
-    {
-        return {
-            init: function ( oData ) {}
-        };
-    }
-    ```
+```js
+function( Bus, Module, ErrorHandler, Api )
+{
+    return {
+        init: function ( oData ) {}
+    };
+}
+```
 
 #### Create a module
 
-    ```js
-    Hydra.module.register( 'moduleId', function( Bus, Module, ErrorHandler, Api )
-    {
-        return {
-            init: function ( oData ) {}
-        };
-    });
-    ```
+```js
+Hydra.module.register( 'moduleId', function( Bus, Module, ErrorHandler, Api )
+{
+    return {
+        init: function ( oData ) {}
+    };
+});
+```
 
 #### Create a module using dependency injection
-    ```js
-    Hydra.module.register( 'moduleId', ['$api', '$bus'], function ( Api, Bus )
-    {
-        return {
-            init: function ( oData ) {}
-        };
-    });
-    ```
+```js
+Hydra.module.register( 'moduleId', ['$api', '$bus'], function ( Api, Bus )
+{
+    return {
+        init: function ( oData ) {}
+    };
+});
+```
 
 The following are available for dependency injection:
 
@@ -140,26 +140,26 @@ Hydra will pass them in the order specified to your function.
 #### Extend a module overriding the base module
 To extend a module you will need to register the base module before extends it.
 
-    ```js
-    Hydra.module.extend( 'moduleId', function( Bus, Module, ErrorHandler, Api )
-    {
-        return {
-            init: function ( oData ) {}
-        };
-    });
-    ```
+```js
+Hydra.module.extend( 'moduleId', function( Bus, Module, ErrorHandler, Api )
+{
+    return {
+        init: function ( oData ) {}
+    };
+});
+```
 
 #### Extend a module creating a new module
 To extend a module you will need to register the base module before extends it.
 
-    ```js
-    Hydra.module.extend( 'moduleId', 'newModuleId', function( Bus, Module, ErrorHandler, Api )
-    {
-        return {
-            init: function ( oData ) {}
-        };
-    });
-    ```
+```js
+Hydra.module.extend( 'moduleId', 'newModuleId', function( Bus, Module, ErrorHandler, Api )
+{
+    return {
+        init: function ( oData ) {}
+    };
+});
+```
 
 This extension allows access the parent methods as classical inheritance.
 
@@ -167,102 +167,102 @@ This extension allows access the parent methods as classical inheritance.
 
 Register base module:
 
-    ```js
-    Hydra.module.register( 'moduleId', function( Bus, Module, ErrorHandler, Api )
-    {
-        return {
-            init: function ( oData ) {},
-            changeTitle: function( sTitle ){
-                document.title = sTitle;
-            }
-        };
-    });
-    ```
+```js
+Hydra.module.register( 'moduleId', function( Bus, Module, ErrorHandler, Api )
+{
+    return {
+        init: function ( oData ) {},
+        changeTitle: function( sTitle ){
+            document.title = sTitle;
+        }
+    };
+});
+```
 
 Create the new module using "extend":
 
-    ```js
-    Hydra.module.extend( 'moduleId', 'newModuleId', function( Bus, Module, ErrorHandler, Api )
-    {
-        return {
-            init: function ( oData ) {},
-            changeTitle: function( sTitle ){
-                sTitle += " " + new Date().getTime();
-                // This is the way of access parent methods.
-                this.__super__.call( "changeTitle", [sTitle] );
-            }
-        };
-    });
-    ```
+```js
+Hydra.module.extend( 'moduleId', 'newModuleId', function( Bus, Module, ErrorHandler, Api )
+{
+    return {
+        init: function ( oData ) {},
+        changeTitle: function( sTitle ){
+            sTitle += " " + new Date().getTime();
+            // This is the way of access parent methods.
+            this.__super__.call( "changeTitle", [sTitle] );
+        }
+    };
+});
+```
 
 #### Decorating modules
 Sometimes is better to decorate our modules instead of extending them. I recommend to use decorate instead of extend modules.
 
-    ```js
-    Hydra.module.decorate( 'baseModuleId', 'decoratedModuleId', function( Bus, baseModule, Module, ErrorHandler, Api )
-    {
-        return {
-            init: function ()
-            {
-                //do something on start a module
-                baseModule.init();
-            },
-            onDestroy: function ()
-            {
-                //do something on stop a module
-                baseModule.onDestroy();
-            }
-        };
-    });
-    ```
+```js
+Hydra.module.decorate( 'baseModuleId', 'decoratedModuleId', function( Bus, baseModule, Module, ErrorHandler, Api )
+{
+    return {
+        init: function ()
+        {
+            //do something on start a module
+            baseModule.init();
+        },
+        onDestroy: function ()
+        {
+            //do something on stop a module
+            baseModule.onDestroy();
+        }
+    };
+});
+```
 
 #### Listening to events
-    ```js
-    Hydra.module.register( 'moduleId', function( Bus, Module, ErrorHandler, Api )
-    {
-        return {
-            events : {
-                'channel': {
-                    'item:action1': function ( oData ) {}
-                }
-            },
-            init: function ( oData ) {
-                /* The subscribing of events is done by Hydra inside the core.
-                * Bus.subscribe( this );
-                */
+```js
+Hydra.module.register( 'moduleId', function( Bus, Module, ErrorHandler, Api )
+{
+    return {
+        events : {
+            'channel': {
+                'item:action1': function ( oData ) {}
             }
-        };
-    });
-    ```
+        },
+        init: function ( oData ) {
+            /* The subscribing of events is done by Hydra inside the core.
+            * Bus.subscribe( this );
+            */
+        }
+    };
+});
+```
 
 #### Publishing actions
 To use the action manager you have accessible using "Bus".
 
 The publish method expect three arguments, but only the first two are mandatory, the channel name and the event name
 
-    ```js
-    Hydra.bus.publish( 'channel_name', 'event_name', data );
-    ```
+```js
+Hydra.bus.publish( 'channel_name', 'event_name', data );
+```
 
 *Tip: 'global' channel is created by default to use it if you want to communicate with other modules that are not related with a specific channel. *
 
-    ```js
-    Hydra.module.register( 'moduleId', function( Bus, Module, ErrorHandler, Api )
-    {
-        return {
-            events : {
-                'channel': {
-                    'item:action1': function ( oData ) {}
-                }
-            },
-            init: function ( oData ) {
-                $( "#button" ).click( function(){
-                    Bus.publish( 'channel', 'item:action1', {} );
-                });
+```js
+Hydra.module.register( 'moduleId', function( Bus, Module, ErrorHandler, Api )
+{
+    return {
+        events : {
+            'channel': {
+                'item:action1': function ( oData ) {}
             }
-        };
-    });
-    ```
+        },
+        init: function ( oData ) {
+            $( "#button" ).click( function(){
+                Bus.publish( 'channel', 'item:action1', {} );
+            });
+        }
+    };
+});
+```
 #### Preprocessing Data on publish actions.
 When the data is pass to the listener actions it gives the same object by default, if you need to pre-process this data before execute the action, you should use the 'preprocessorPublishData' method in Hydra.bus.
 The callback that you pass will get two arguments:
@@ -271,11 +271,11 @@ The callback that you pass will get two arguments:
 
 Example of a code that returns a copy of the data object
 
-    ```js
-    Hydra.bus.preprocessorPublishData( function ( oData, clone ) {
-        return clone( oData );
-    });
-    ```
+```js
+Hydra.bus.preprocessorPublishData( function ( oData, clone ) {
+    return clone( oData );
+});
+```
 If you need compatibility with the previous event manager called Action, you can add it in your code to maintain compatibility with previous version's code. You can download it from: [Action](https://github.com/tcorral/Hydra_Extensions/tree/master/Sandbox)
 
 


### PR DESCRIPTION
As we are using triple ` there is no need to tab the code.

The benefit of using triple ` is that you can specify language for syntax highlighting.
